### PR TITLE
OS Agnostic Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *~
 *.pyc
-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.pyc
+cache


### PR DESCRIPTION
This PR enables functional downloading and caching of SRTM tiles on Windows.

Because windows and linux do not share a temporary files location, placing it in the home directory level seemed a reasonable solution.

User Changes:
- Windows: Did not work, now works
- Linux: SRTM cache is now a '.ImageAnalysis/' folder at the user's home directory.